### PR TITLE
Allow fair comparison between io-ts and Zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,12 +481,7 @@ const B = t.partial({
 const C = t.intersection([A, B]);
 
 type C = t.TypeOf<typeof C>;
-/*
-returns {
-	foo: string;
-	bar?: number | undefined
-}
-*/
+// returns { foo: string; bar?: number | undefined }
 ```
 
 You must define the required and optional props in separate object validators, pass the optionals through `t.partial` (which marks all properties as optional), then combine them with `t.intersection`.


### PR DESCRIPTION
Below the Zod example the line reads "This more declarative API makes schema definitions vastly more concise.", having the comment spread out as it was made the io-ts example look larger.

I feel this makes it more fair and about the code. I am in no way affiliated with io-ts just happen to be a passer by.