### PR TITLE
Update Yum comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,20 +1040,7 @@ Doesn't support static type inference. 😕
 
 Yup is a full-featured library that was implemented first in vanilla JS, with TypeScript typings added later.
 
-Yup supports static type inference, but unfortunately the inferred types aren't actually correct. Currently, the yup package treats all object properties as optional by default:
-
-```ts
-const schema = yup.object({
-  asdf: yup.string(),
-});
-schema.validate({}); // passes
-
-type SchemaType = yup.InferType<typeof schema>;
-// returns { asdf: string }
-// should be { asdf?: string }
-```
-
-Yup also mis-infers the type of required arrays.
+Yup mis-infers the type of required arrays.
 
 ```ts
 const numList = yup


### PR DESCRIPTION
Hi there, I was just made aware of yup so I wanted to take a look at how it compared to zod and I found this.

It looks like properties within yup now default to non-optional.

The remaining point is interesting, but the conclusion of "But it's not acceptable that an object that's assignable to the inferred TypeScript type can fail validation by the validator it was inferred from." is probably unrealistic for a library like yup, which also validates the values, not just the shape. 

One would need a type system capable of expressing dependent types to really meet that criticism. The reality is that yup validates both the types and the values simultaneously. I think it definitely could improve the required array type.