### PR TITLE
Remove erroneous character from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,6 @@ ZodError {
 
 Note that the `path` is set to `["confirm"]`, so you can easily display this error underneath the "Confirm password" textbox.
 
-j
-
 ## Type inference
 
 You can extract the TypeScript type of any schema with `z.infer<typeof mySchema>`.


### PR DESCRIPTION
It looks like this ``j`` wasn't intended to be in the doc.