### PR TITLE
Test that all errors are collected even if schema instance is reused.

### DIFF
--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -1,0 +1,27 @@
+import * as z from '..';
+
+test('all errors', () => {
+  const propertySchema = z.string();
+  const schema = z.object({
+    a: propertySchema,
+    b: propertySchema,
+    c: propertySchema.min(0), // The error is properly included when schema reference changes.
+  });
+
+  try {
+    schema.parse({
+      a: null,
+      b: null,
+      c: null,
+    });
+  } catch (error) {
+    expect(error.formErrors).toStrictEqual({
+      formErrors: [],
+      fieldErrors: {
+        a: ['Expected string, received null'],
+        b: ['Expected string, received null'],
+        c: ['Expected string, received null'],
+      },
+    });
+  }
+});


### PR DESCRIPTION
It seems that some errors are omitted when reusing schema instance. Adding a simple test.