### PR TITLE
Fix confirm example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,11 @@ z.object({
   password: z.string(),
   confirm: z.string(),
 })
-  .refine(data => data.confirm === data.password, {
+  .refine(data => data.password === data.confirm, {
     message: "Passwords don't match",
     path: ['confirm'],
   })
-  .parse({ password: 'asdf', confirmPassword: 'qwer' });
+  .parse({ password: 'asdf', confirm: 'qwer' });
 ```
 
 Because you provided a `path` parameter, the resulting error will be:


### PR DESCRIPTION
The current one has an invalid key name: `confirm vs confirmPassword` mismatch typo.