### PR TITLE
fixed babel-jest import bug (#125)

### DIFF
--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -1,4 +1,4 @@
-import * as z from '..';
+import * as z from '../index';
 
 export namespace partialUtil {
   export type RootDeepPartial<T extends z.ZodTypeAny> = {

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,6 +1,6 @@
 import { ZodParser, ParseParams, MakeErrorData } from '../parser';
 import { util } from '../helpers/util';
-import { ZodErrorCode, ZodArray, ZodUnion, ZodNull, ZodUndefined } from '..';
+import { ZodErrorCode, ZodArray, ZodUnion, ZodNull, ZodUndefined } from '../index';
 import { CustomError } from '../ZodError';
 
 export enum ZodTypes {


### PR DESCRIPTION
I get an error when accessing `nullable` method when using `babel-jest`. I've discovered that the error is due to the ZodUnion file not being imported correctly.

`TypeError: Cannot read property 'create' of undefined` at ZodNumber.ZodType.nullable (node_modules/zod/src/types/base.ts:114:62)

I use explicit import of barrels files for fix this problems

Relates: 
https://github.com/vriad/zod/issues/125
https://github.com/vriad/zod/issues/119 
https://github.com/vriad/zod/commit/c6fff3a0e9be02da32dda0dc9e58fd853fb628a3