### PR TITLE
Example of `dynamicRefinement` to validate by dynamic constraints.

### DIFF
--- a/src/__tests__/dynamicRefinement.test.ts
+++ b/src/__tests__/dynamicRefinement.test.ts
@@ -6,7 +6,7 @@ import { performance } from 'perf_hooks';
 test('dynamicRefinement', () => {
   enum DataType {
     STRING = 'STRING',
-    INT = 'NUMBER',
+    INT = 'INT',
   }
 
   const formSchema = z

--- a/src/__tests__/dynamicRefinement.test.ts
+++ b/src/__tests__/dynamicRefinement.test.ts
@@ -1,0 +1,65 @@
+import * as z from '../index';
+import { ZodError } from '../index';
+// @ts-ignore
+import { performance } from 'perf_hooks';
+
+test('dynamicRefinement', () => {
+  enum DataType {
+    STRING = 'STRING',
+    INT = 'NUMBER',
+  }
+
+  const formSchema = z
+    .object({
+      // @ts-ignore
+      type: z.nativeEnum(DataType),
+      constraints: z.object({
+        max: z.number().optional(),
+      }),
+      value: z.union([z.string(), z.number()]),
+    })
+    .dynamicRefinement((zodError, value) => {
+      let schema: z.ZodTypeAny = z.unknown();
+      switch (value.type) {
+        case DataType.INT:
+          if (value.constraints.max != undefined) {
+            schema = z
+              .number()
+              .max(value.constraints.max)
+              .int();
+          }
+          break;
+        case DataType.STRING:
+          break;
+      }
+      try {
+        schema.parse(value.value);
+        return;
+      } catch (error) {
+        if (error instanceof ZodError) {
+          zodError.addErrors(error.errors.map(e => ({ ...e, path: ['value'] })));
+        }
+      }
+    });
+
+  const outputSchema = formSchema.omit({ constraints: true });
+
+  const transform = (input: z.infer<typeof formSchema>): z.infer<typeof outputSchema> => {
+    const { constraints, ...clean } = input;
+    return clean;
+  };
+
+  //   const time = performance.now();
+  try {
+    const validValue = formSchema.parse({ type: DataType.INT, value: 10.1, constraints: { max: 10 } });
+    const outputValue = transform(validValue);
+    console.log('Valid:', outputValue);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      console.log(JSON.stringify(error.errors, null, 2));
+    } else {
+      throw error;
+    }
+  }
+  //   console.log(performance.now() - time);
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -487,11 +487,20 @@ export const ZodParser = (schemaDef: z.ZodTypeDef) => (
       util.assertNever(def);
   }
 
+  // had to throw earlier to ensure that custom check input value is properly typed
+  if (!error.isEmpty) {
+    throw error;
+  }
+
   const customChecks = def.checks || [];
   for (const check of customChecks) {
-    if (!check.check(returnValue)) {
-      const { check: checkMethod, ...noMethodCheck } = check;
-      error.addError(makeError(noMethodCheck));
+    if (typeof check === 'function') {
+      check(error, returnValue);
+    } else {
+      if (!check.check(returnValue)) {
+        const { check: checkMethod, ...noMethodCheck } = check;
+        error.addError(makeError(noMethodCheck));
+      }
     }
   }
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -34,7 +34,7 @@ type InternalCheck<T> =
   | ({
       check: (arg: T) => any;
     } & MakeErrorData)
-  | ((error: ZodError, arg: T) => MakeErrorData | void);
+  | ((error: ZodError, arg: T) => void);
 
 // type Check<T> = {
 //   check: (arg: T) => any;

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -30,9 +30,11 @@ export enum ZodTypes {
 export type ZodTypeAny = ZodType<any, any>;
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 
-type InternalCheck<T> = {
-  check: (arg: T) => any;
-} & MakeErrorData;
+type InternalCheck<T> =
+  | ({
+      check: (arg: T) => any;
+    } & MakeErrorData)
+  | ((error: ZodError, arg: T) => MakeErrorData | void);
 
 // type Check<T> = {
 //   check: (arg: T) => any;
@@ -133,6 +135,8 @@ export abstract class ZodType<Type, Def extends ZodTypeDef = ZodTypeDef> {
       checks: [...(this._def.checks || []), refinement],
     }) as this;
   };
+
+  dynamicRefinement: (refinement: InternalCheck<Type>) => this = refinement => this._refinement(refinement);
 
   constructor(def: Def) {
     this._def = def;


### PR DESCRIPTION
I have a scenario in which some validation constraints are fetched from a server. The proposed changes might solve the use case without introducing a "validation context" feature.

There is an evident performance tradeoff - I'm creating (potentially lots of) schemas dynamically during validation to keep the API as simple as possible. Nonetheless, I think there are cases when such a solution is sufficient. What do you think?

Thanks again for the lib!