### PR TITLE
feat: make nonstrict object props "unknown" rather than "any"

### DIFF
--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -63,7 +63,7 @@ type SetKey<Target extends object, Key extends string, Value extends any> = obje
 
 type ZodObjectType<T extends z.ZodRawShape, Params extends ZodObjectParams> = Params['strict'] extends true
   ? objectUtil.ObjectType<T>
-  : objectUtil.Flatten<objectUtil.ObjectType<T> & { [k: string]: any }>;
+  : objectUtil.Flatten<objectUtil.ObjectType<T> & { [k: string]: unknown }>;
 
 export class ZodObject<
   T extends z.ZodRawShape,


### PR DESCRIPTION
This makes them remain type safe, while allowing you to be flexible if you are parsing/validating large JSON objects and you only care about a few fields.

BREAKING CHANGE: un-validated fields on "nonstrict" objects are `unknown` instead of `any`