### PR TITLE
Use .default() value only when schema is null or undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,7 +1595,7 @@ const stringWithDefault = z.transformer(
 );
 ```
 
-Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas.
+Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas. A default value will be used if the schema is `null` or `undefined`.
 
 ```ts
 z.string().default('default value');

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -59,6 +59,27 @@ test('default', () => {
   expect(data).toEqual('asdf');
 });
 
+test('default when property is null or undefined', () => {
+  const data = z.object({
+    foo: z.boolean().nullable().default(true),
+    bar: z.boolean().default(true)
+  }).parse({ foo: null });
+
+  expect(data).toEqual({ foo: true, bar: true });
+});
+
+test('default with falsy values', () => {
+  const schema = z.object({
+    emptyStr: z.string().default('def'),
+    zero: z.number().default(5),
+    falseBoolean: z.boolean().default(true)
+  })
+  const input = { emptyStr: '', zero: 0, falseBoolean: true };
+  const output = schema.parse(input);
+  // defaults are not supposed to be used
+  expect(output).toEqual(input);
+});
+
 test('object typing', () => {
   const t1 = z.object({
     stringToNumber,

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -324,7 +324,7 @@ export abstract class ZodType<
     def: T,
   ) => ZodTransformer<Opt, this> = def => {
     return ZodTransformer.create(this.optional(), this, (x: any) => {
-      return (x || def) as any;
+      return (x ?? def) as any;
     }) as any;
   };
 


### PR DESCRIPTION
**Before this change**:
```ts
const schema = z.object({
  sandbox: z.boolean().default(true)
});

// Good - returns { sandbox: true } - which makes sense as it's not supplied
schema.parse({}); 

// Bad! - returns { sandbox: true } even though I've provided a  value for it.
schema.parse({ sandbox: false }); 
```

**After this change**:
```ts
const schema = z.object({
  sandbox: z.boolean().default(true)
});

// Good - returns { sandbox: true } - which makes sense as it's not supplied
schema.parse({}); 

// Good - returns { sandbox: false } as a value was supplied to the sandbox property
schema.parse({ sandbox: false }); 
```

As I'm using the null coalescing operator it means either `null` or `undefined` values will cause the default value to be used.
We might want to limit this only to `undefined` values so it matches the same behaviour of `joi` and `yup`. Let me know what you think.

Fixes #162 