### PR TITLE
fix(parser): incorrect promise error handling

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -476,15 +476,7 @@ export const ZodParser = (schemaDef: z.ZodTypeDef) => (
         // setError(error);
         throw error;
       }
-      return new Promise(async (res, rej) => {
-        const objValue = await obj;
-        try {
-          const parsed = def.type.parse(objValue, params);
-          res(parsed);
-        } catch (err) {
-          rej(err);
-        }
-      });
+      return obj.then((objValue) => def.type.parse(objValue, params));
 
     default:
       util.assertNever(def);


### PR DESCRIPTION
Currently, if you have a Zod Function Schema and you say it returns a Promise value then Zod will create a new Promise wrapping the returned Promise. When the wrapped Promise resolves it will validate it with the Promise type parser and if it doesn't validate it will reject the new Promise or resolve it if the parsing succeeds.

However, wrapping a Promise into a new Promise breaks catching the Promise rejection further up the stack as the Promise that generates the error is not the Promise anything is attaching `.catch` too or wrapping in a `try {} catch {}` block.

Instead of wrapping the Promise we can simply just add a new `.then` chain which performs the validation. If it throws it will automatically reject the Promise and it ensures that the correct Promise is having error handling added to it further up the stack.

I created this in the web-editor and haven't tested any other scenario, but I have applied the same patch to my local copy of Zod and it now correctly handles rejected promises.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vriad/zod/185)
<!-- Reviewable:end -->
