### PR TITLE
feat: add the current path as a refinement `check` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,7 +1596,7 @@ const stringWithDefault = z.transformer(
 );
 ```
 
-Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas.
+Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas. A default value will be used if the schema is `null` or `undefined`.
 
 ```ts
 z.string().default('default value');

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Some other great aspects:
 - Immutability: methods (i.e. `.optional()` return a new instance
 - Concise, chainable interface
 - Functional approach: [parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
+- Works with plain JavaScript too! You don't need to use TypeScript.
 
 # Sponsorship
 

--- a/README.md
+++ b/README.md
@@ -1596,7 +1596,7 @@ const stringWithDefault = z.transformer(
 );
 ```
 
-Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas. A default value will be used if the schema is `null` or `undefined`.
+Equivalently you can express this using the built-in `.default()` method, available on all Zod schemas. The default value will be used if and only if the schema is `undefined`.
 
 ```ts
 z.string().default('default value');

--- a/src/PseudoPromise.ts
+++ b/src/PseudoPromise.ts
@@ -1,10 +1,13 @@
+import {
+  ZodError
+} from './ZodError';
 type Func = (...args: any[]) => any;
-type Functions = Func[];
+type FunctionTuples = ([string, Func])[];
 export class PseudoPromise<ReturnType = undefined> {
   readonly _return: ReturnType;
-  functions: Functions;
-  constructor(funcs: Functions = []) {
-    this.functions = funcs;
+  functionTuples: FunctionTuples;
+  constructor(funcs: FunctionTuples = []) {
+    this.functionTuples = funcs;
   }
 
   static all = <T extends PseudoPromise<any>[]>(pps: T) => {
@@ -61,8 +64,10 @@ export class PseudoPromise<ReturnType = undefined> {
           // const asyncValue: any = {};
           const items = await Promise.all(
             Object.keys(pps).map(async k => {
-              const v = await pps[k].getValueAsync();
-              return [k, v] as [string, any];
+              // try {
+                const x = pps[k].getValueAsync();
+                const v = await x;
+                return [k, v] as [string, any];
             }),
           );
           // const resolvedItems = await Promise.all(
@@ -100,7 +105,13 @@ export class PseudoPromise<ReturnType = undefined> {
   then = <NewReturn>(
     func: (arg: ReturnType, ctx: { async: boolean }) => NewReturn,
   ): PseudoPromise<NewReturn extends Promise<infer U> ? U : NewReturn> => {
-    return new PseudoPromise([...this.functions, func]);
+    return new PseudoPromise([...this.functionTuples, ['t', func]]);
+  };
+
+  catch = <NewReturn>(
+    func: (err: ZodError | any, ctx: { async: boolean }) => NewReturn,
+  ): PseudoPromise<NewReturn extends Promise<infer U> ? U : NewReturn> => {
+    return new PseudoPromise([...this.functionTuples, ['c', func]]);
   };
 
   // getValue = (
@@ -120,8 +131,10 @@ export class PseudoPromise<ReturnType = undefined> {
     // // if (this._cached.value) return this._cached.value;
     let val: any = undefined;
 
-    for (const f of this.functions) {
-      val = f(val, { async: false });
+    for (const [t, f] of this.functionTuples) {
+      if (t === 't') {
+        val = f(val, { async: false });
+      }
 
       // if (val instanceof Promise && allowPromises === false) {
       //   throw new Error('found_promise');
@@ -131,31 +144,42 @@ export class PseudoPromise<ReturnType = undefined> {
     return val;
   };
 
-  getValueAsync = async () => {
-    try {
-      // // if (this._cached.value) return this._cached.value;
-      let val: any = undefined;
-      for (const f of this.functions) {
-        val = await f(val, { async: true });
+  getValueAsync: Function = async (that: PseudoPromise<any> = this) => {
+    // // if (this._cached.value) return this._cached.value;
+    let val: any = undefined;
+    
+    for (let index = 0; index < that.functionTuples.length; index++) {
+      const [t, f] = that.functionTuples[index];
+      try {
+        if (t === 't') {
+          val = await f(val, { async: true }); 
+        }
+      } catch (err) {
+        const cIndex = that.functionTuples.findIndex((x, i) => x[0] === 'c' && i > index);
 
-        if (val instanceof PseudoPromise) {
-          throw new Error('DO NOT RETURN PSEUDOPROMISE FROM FUNCTIONS');
+        if (cIndex > -1) {
+          val = await that.functionTuples[cIndex][1](err);
+          index = cIndex;
+        } else {
+          throw err;
         }
-        if (val instanceof Promise) {
-          throw new Error('DO NOT RETURN PROMISE FROM FUNCTIONS');
-        }
-        // while (!!val.then) {
-        //   if (val instanceof PseudoPromise) {
-        //     val = await val.toPromise();
-        //   } else {
-        //     val = await val;
-        //   }
-        // }
       }
-      // this._cached.value = val;
-      return val;
-    } catch (err) {
-      throw err;
+
+      if (val instanceof PseudoPromise) {
+        throw new Error('DO NOT RETURN PSEUDOPROMISE FROM FUNCTIONS');
+      }
+      if (val instanceof Promise) {
+        throw new Error('DO NOT RETURN PROMISE FROM FUNCTIONS');
+      }
+      // while (!!val.then) {
+      //   if (val instanceof PseudoPromise) {
+      //     val = await val.toPromise();
+      //   } else {
+      //     val = await val;
+      //   }
+      // }
     }
+    // this._cached.value = val;
+    return val;
   };
 }

--- a/src/__tests__/async-parsing.test.ts
+++ b/src/__tests__/async-parsing.test.ts
@@ -359,7 +359,41 @@ test('transformer async parse', async () => {
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
 
-test('async validation multiple errors', async () => {
+test('async validation non-empty strings', async () => {
+  const base = z.object({
+    hello: z.string().refine(x => x && x.length > 0),
+    foo: z.string().refine(x => x && x.length > 0)
+  })
+
+  const testval = {hello: '', foo: ''}
+  const result1 = base.safeParse(testval)
+  const result2 = base.safeParseAsync(testval)
+  
+  const r1 = result1
+  return result2.then(r2 => {
+    if (r1.success === false && r2.success === false) 
+      expect(r1.error.issues.length).toBe(r2.error.issues.length) // <--- r1 has length 2, r2 has length 1
+  });
+});
+
+test('async validation multiple errors 1', async () => {
+  const base = z.object({
+    hello: z.string(),
+    foo: z.number()
+  })
+
+  const testval = {hello: 3, foo: "hello"}
+  const result1 = base.safeParse(testval)
+  const result2 = base.safeParseAsync(testval)
+  
+  const r1 = result1
+  return result2.then(r2 => {
+    if (r1.success === false && r2.success === false) 
+      expect(r1.error.issues.length).toBe(r2.error.issues.length)
+  });
+});
+
+test('async validation multiple errors 2', async () => {
   const base = (is_async?: boolean) => z.object({
     hello: z.string(),
     foo: z.object({
@@ -374,7 +408,7 @@ test('async validation multiple errors', async () => {
   const r1 = result1
   return result2.then(r2 => {
     if (r1.success === false && r2.success === false) 
-      expect(r1.error.issues.length).toBe(r2.error.issues.length) // <--- r1 has length 2, r2 has length 1
+      expect(r1.error.issues.length).toBe(r2.error.issues.length)
   });
 });
 

--- a/src/__tests__/async-parsing.test.ts
+++ b/src/__tests__/async-parsing.test.ts
@@ -389,7 +389,7 @@ test('async validation multiple errors 1', async () => {
   const r1 = result1
   return result2.then(r2 => {
     if (r1.success === false && r2.success === false) 
-      expect(r1.error.issues.length).toBe(r2.error.issues.length)
+      expect(r2.error.issues.length).toBe(r1.error.issues.length)
   });
 });
 
@@ -408,7 +408,33 @@ test('async validation multiple errors 2', async () => {
   const r1 = result1
   return result2.then(r2 => {
     if (r1.success === false && r2.success === false) 
-      expect(r1.error.issues.length).toBe(r2.error.issues.length)
+      expect(r2.error.issues.length).toBe(r1.error.issues.length)
+  });
+});
+
+test('ensure early async failure prevents follow-up refinement checks', async () => {
+  let count = 0;
+  const base = z.object({
+    hello: z.string(),
+    foo: z.number()
+      .refine(async () => { 
+        count++; 
+        return false; 
+      })
+      .refine(async () => { 
+        count++
+        return true
+      })
+      
+  })
+
+  const testval = {hello: "bye", foo: 3}
+  const result = base.safeParseAsync(testval)
+
+  return result.then(r => {
+    if (r.success === false) 
+      expect(r.error.issues.length).toBe(1)
+      expect(count).toBe(1)
   });
 });
 

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -236,3 +236,16 @@ test('catchall overrides strict', () => {
     asdf: 1234,
   });
 });
+
+test('test that optional keys are unset', async () => {
+  const SNamedEntity = z.object({
+    id: z.string(),
+    set: z.string().optional(),
+    unset: z.string().optional(),
+  });
+  const result = await SNamedEntity.parse({
+    id: 'asdf',
+    set: undefined,
+  });
+  expect(Object.keys(result)).toEqual(['id', 'set']);
+});

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -60,20 +60,25 @@ test('default', () => {
 });
 
 test('default when property is null or undefined', () => {
-  const data = z.object({
-    foo: z.boolean().nullable().default(true),
-    bar: z.boolean().default(true)
-  }).parse({ foo: null });
+  const data = z
+    .object({
+      foo: z
+        .boolean()
+        .nullable()
+        .default(true),
+      bar: z.boolean().default(true),
+    })
+    .parse({ foo: null });
 
-  expect(data).toEqual({ foo: true, bar: true });
+  expect(data).toEqual({ foo: null, bar: true });
 });
 
 test('default with falsy values', () => {
   const schema = z.object({
     emptyStr: z.string().default('def'),
     zero: z.number().default(5),
-    falseBoolean: z.boolean().default(true)
-  })
+    falseBoolean: z.boolean().default(true),
+  });
   const input = { emptyStr: '', zero: 0, falseBoolean: true };
   const output = schema.parse(input);
   // defaults are not supposed to be used

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -59,6 +59,27 @@ test('default', () => {
   expect(data).toEqual('asdf');
 });
 
+test('default when property is null or undefined', () => {
+  const data = z.object({
+    foo: z.boolean().nullable().default(true),
+    bar: z.boolean().default(true)
+  }).parse({ foo: null });
+
+  expect(data).toEqual({ foo: true, bar: true });
+});
+
+test('default with falsy values', () => {
+  const schema = z.object({
+    emptyStr: z.string().default('def'),
+    zero: z.number().default(5),
+    falseBoolean: z.boolean().default(true)
+  })
+  const input = { emptyStr: '', zero: 0, falseBoolean: true };
+  const output = schema.parse(input);
+  // defaults are not supposed to be used
+  expect(output).toEqual(input);
+});
+
 test('object typing', () => {
   const t1 = z.object({
     stringToNumber,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -375,20 +375,22 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         if (!keyValidator) continue;
 
         // check if schema and value are both optional
-        try {
-          keyValidator.parse(undefined, {
-            ...params,
-            path: [...params.path, key],
-          });
 
-          // const keyDataType = getParsedType(data[key]);
-          if (!Object.keys(data).includes(key)) {
-            // schema is optional
-            // data is undefined
-            // don't explicity add undefined to outut
-            continue;
-          }
-        } catch (err) {}
+        // const keyDataType = getParsedType(data[key]);
+        if (!Object.keys(data).includes(key)) {
+          try {
+            const output = keyValidator.parse(undefined, {
+              ...params,
+              path: [...params.path, key],
+            });
+            if (output === undefined) {
+              // schema is optional
+              // data is undefined
+              // don't explicity add undefined to outut
+              continue;
+            }
+          } catch (err) {}
+        }
 
         objectPromises[key] = new PseudoPromise().then(() => {
           try {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -435,7 +435,8 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       PROMISE = PseudoPromise.object(objectPromises).then(resolvedObject => {
         Object.assign(RESULT.output, resolvedObject);
         return RESULT.output;
-      }).catch(err => {
+      })
+      .catch(err => {
         if (err instanceof ZodError) {
           ERROR.addIssues(err.issues);
         } 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -435,6 +435,12 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       PROMISE = PseudoPromise.object(objectPromises).then(resolvedObject => {
         Object.assign(RESULT.output, resolvedObject);
         return RESULT.output;
+      }).catch(err => {
+        if (err instanceof ZodError) {
+          ERROR.addIssues(err.issues);
+        } 
+
+        return INVALID;
       });
 
       break;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -969,26 +969,44 @@ export const ZodParser = (schema: z.ZodType<any>) => (
   } else {
     // if (params.async == true) {
     const checker = async () => {
-      const resolvedValue = await PROMISE.getValueAsync();
-
-      await Promise.all(
-        customChecks.map(async check => {
-          await check.check(resolvedValue, checkCtx);
-          // if (!checkResult) {
-          //   const { check: checkMethod, ...noMethodCheck } = check;
-          //   ERROR.addIssue(makeError(noMethodCheck));
-          // } else {
-          // }
-        }),
-      );
-
-      if (resolvedValue === INVALID && ERROR.isEmpty) {
-        ERROR.addIssue(
-          makeError({
-            code: ZodIssueCode.custom,
-            message: 'Invalid',
-          }),
-        );
+      let resolvedValue = await PROMISE.getValueAsync();
+ 
+      if (resolvedValue !== INVALID) {
+        let someError: boolean = false;
+        await customChecks.reduce((previousPromise, check) => {
+          return previousPromise.then(async () => {
+            if (!someError) {
+              const len = ERROR.issues.length;
+              await check.check(resolvedValue, checkCtx);
+              if (len < ERROR.issues.length)
+                someError = true;
+            }
+          });
+        }, Promise.resolve());
+      }
+      // if (resolvedValue !== INVALID) {
+      //   await Promise.all(
+      //     customChecks.map(async check => {
+      //       await check.check(resolvedValue, checkCtx);
+      //         if (ERROR.issues.length > len) someError = true;
+      //       }
+      //       // if (!checkResult) {
+      //       //   const { check: checkMethod, ...noMethodCheck } = check;
+      //       //   ERROR.addIssue(makeError(noMethodCheck));
+      //       // } else {
+      //       // }
+      //     }),
+      //   );
+      // } 
+      else {
+        if (ERROR.isEmpty) {
+          ERROR.addIssue(
+            makeError({
+              code: ZodIssueCode.custom,
+              message: 'Invalid',
+            }),
+          );
+        }
       }
 
       if (!ERROR.isEmpty) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -943,7 +943,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
     // }
 
     for (const check of customChecks) {
-      const checkResult = check.check(resolvedValue, checkCtx);
+      const checkResult = check.check(resolvedValue, checkCtx, params.path);
       if (checkResult instanceof Promise)
         throw new Error(
           "You can't use .parse on a schema containing async refinements. Use .parseAsync instead.",
@@ -977,7 +977,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           return previousPromise.then(async () => {
             if (!someError) {
               const len = ERROR.issues.length;
-              await check.check(resolvedValue, checkCtx);
+              await check.check(resolvedValue, checkCtx, params.path);
               if (len < ERROR.issues.length)
                 someError = true;
             }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,17 +1,17 @@
 import * as z from '.';
 
 const run = async () => {
-  const SNamedEntity = z.object({
-    id: z.string(),
-    set: z.string().optional(),
-    unset: z.string().optional(),
-  });
-  const result = await SNamedEntity.parse({
-    id: 'asdf',
-    set: undefined,
-  });
-  console.log(result);
-  console.log(Object.keys(result));
+  const data = z
+    .object({
+      foo: z
+        .boolean()
+        .nullable()
+        .default(true),
+      bar: z.boolean().default(true),
+    })
+    .parse({ foo: null });
+
+  console.log(data);
 };
 run();
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,17 +1,30 @@
 import * as z from '.';
-// import { Scalars } from './helpers/primitive';
 
-const obj = z.object({
-  primitiveTuple: z.tuple([z.string(), z.number()]),
-  nonprimitiveTuple: z.tuple([z.string(), z.number().array()]),
-});
+const run = async () => {
+  const SNamedEntity = z.object({
+    id: z.string(),
+    set: z.string().optional(),
+    unset: z.string().optional(),
+  });
+  const result = await SNamedEntity.parse({
+    id: 'asdf',
+    set: undefined,
+  });
+  console.log(result);
+  console.log(Object.keys(result));
+};
+run();
 
-type obj = z.infer<typeof obj>;
+// export const T = z.object({
+//   test: z.string().optional(),
+// });
 
-const prim = obj.primitives();
-console.log(prim.shape);
-const nonprim = obj.nonprimitives();
-console.log(nonprim.shape);
-// .primitives();
+// console.log(T.safeParse({}));
 
-// type t1 = [[string, number]] extends [Scalars] ? true : false;
+// const r = T.safeParse({});
+
+// if (r.success) {
+//   console.log(JSON.stringify(r.data));
+// }
+
+// console.log(JSON.stringify({ test: undefined, test2: undefined }, null, 2));

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -11,6 +11,7 @@ import {
 import { ZodOptionalType } from './optional';
 import { ZodNullableType } from './nullable';
 import { ZodCustomIssue } from '../ZodError';
+import { util } from '../helpers/util';
 
 export enum ZodTypes {
   string = 'string',
@@ -72,7 +73,7 @@ type InternalCheck<T> = {
 //   // params?: {[k:string]:any}
 // } & util.Omit<CustomError, 'code' | 'path'>;
 
-type CustomErrorParams = Partial<Omit<ZodCustomIssue, 'code'>>;
+type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, 'code'>>;
 // type Check<T> = {
 //   check: (arg: T) => any;
 //   refinementError: (arg: T) => CustomErrorParams;

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -324,7 +324,7 @@ export abstract class ZodType<
     def: T,
   ) => ZodTransformer<Opt, this> = def => {
     return ZodTransformer.create(this.optional(), this, (x: any) => {
-      return (x || def) as any;
+      return (x ?? def) as any;
     }) as any;
   };
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -324,7 +324,7 @@ export abstract class ZodType<
     def: T,
   ) => ZodTransformer<Opt, this> = def => {
     return ZodTransformer.create(this.optional(), this, (x: any) => {
-      return (x ?? def) as any;
+      return x === undefined ? def : x;
     }) as any;
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,10 +3695,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.7:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.9:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 undefsafe@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
This is a follow-up PR to (#187). It's not intended for merge, but just to ask the question, what is the proper way to integrate the path into a custom refinement error message?  I've made a PR which injects the `params.path` from the parser into the refinement `check` args.  Is there a better way?  For example if I want to throw a ZodError in my custom refinement with the code of `ZodIssueCode.invalid_string` it requires the `path` to be set but in the current signature the refinement validation function doesn't have access to the path that is currently being validated.  This PR does the work of passing that information down from the parser.

This PR also includes a change which swaps out parallel custom refinements validations (`Promise.all`) for a serial approach so failed earlier validations will not cause later validations to be run.  This is useful, for example, when mixing sync and async validations. When a earlier-in-the-queue sync validation fails, a more costly async validations should not be run.